### PR TITLE
inverter-temperature alarm via lag

### DIFF
--- a/redash/maps/prod.yaml
+++ b/redash/maps/prod.yaml
@@ -125,6 +125,9 @@ query:
   116: queries/irradiation-and-inverter-power-timeseries-union
   115: queries/produccio-respecto-a-prediccio-meteologica
   136: queries/sonda-d-irradiacio-actual-historics
+  139: queries/alarma-3-inversors-temperatura-anomala-via-lag
+  138: queries/alarma-3-inversors-temperatura-anomala-scatter
+  137: queries/alarma-3-inversors-temperatura-anomala-historic
 visualization:
   44: queries/metriques-d-inversor-v2-una-metrica/visualizations/table.yaml
   45: queries/metriques-d-inversor-v2-una-metrica/visualizations/chart.yaml
@@ -319,6 +322,12 @@ visualization:
   197: queries/produccio-respecto-a-prediccio-meteologica/visualizations/chart.yaml
   217: queries/sonda-d-irradiacio-actual-historics/visualizations/chart.yaml
   215: queries/sonda-d-irradiacio-actual-historics/visualizations/table.yaml
+  222: queries/alarma-3-inversors-temperatura-anomala-via-lag/visualizations/table.yaml
+  223: queries/alarma-3-inversors-temperatura-anomala-via-lag/visualizations/chart.yaml
+  220: queries/alarma-3-inversors-temperatura-anomala-scatter/visualizations/table.yaml
+  221: queries/alarma-3-inversors-temperatura-anomala-scatter/visualizations/chart.yaml
+  218: queries/alarma-3-inversors-temperatura-anomala-historic/visualizations/table.yaml
+  219: queries/alarma-3-inversors-temperatura-anomala-historic/visualizations/chart.yaml
 dashboard:
   4: dashboards/dashboard-dinamic-de-planta
   2: dashboards/dashboard-general-de-planta

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-historic/metadata.yaml
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-historic/metadata.yaml
@@ -1,0 +1,21 @@
+can_edit: true
+data_source_id: datasources/plantmonitor.yaml
+description: null
+is_archived: false
+is_draft: false
+is_favorite: false
+is_safe: true
+name: 'Alarma 3: Inversors temperatura anòmala històric'
+options:
+  parameters:
+  - name: interval
+    title: interval
+    global: false
+    value: d_this_year
+    type: datetime-range
+    locals: []
+schedule: null
+tags:
+- Alarma
+- Projectes
+version: 1

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-historic/query.sql
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-historic/query.sql
@@ -1,0 +1,43 @@
+select time at time zone 'Europe/Madrid' as time,
+plant_name,
+inverter_name
+from (
+	select
+		date_trunc('hour', time) as time,
+		plant_name,
+		inverter_name,
+		min(tmp_diff) as tmp_diff_min,
+		min(temperature_dc) as temperature_dc_min
+	from (
+		SELECT
+			subireg.time AS TIME,
+			pl.name AS plant_name,
+			inv.name AS inverter_name,
+			subireg.temperature_dc as temperature_dc,
+			subireg.temperature_dc - subinvs.temperature_dc as tmp_diff
+		FROM inverterregistry AS subireg
+		LEFT JOIN inverter as inv ON inv.id = subireg.inverter
+		LEFT JOIN plant as pl ON pl.id = inv.plant
+		LEFT JOIN (
+			SELECT distinct on (time, plant)
+				subireg.time AS TIME,
+				pl.name AS plant_name,
+				inv.name AS inverter_name,
+				temperature_dc as temperature_dc
+			FROM inverterregistry AS subireg
+			LEFT JOIN inverter as inv ON inv.id = subireg.inverter
+			LEFT JOIN plant as pl ON pl.id = inv.plant
+			where time between '{{ interval.start }}' and '{{ interval.end }}'
+			order by time, plant, temperature_dc
+		) subinvs
+		ON subinvs.time = subireg.time and subinvs.plant_name = pl.name
+	) diff_inverter
+	where time between '{{ interval.start }}' and '{{ interval.end }}'
+	group by date_trunc('hour', time), plant_name, inverter_name
+	order by time, inverter_name
+) as historic_diff_tmp
+where tmp_diff_min > 100 and temperature_dc_min >= 400
+and time between '{{ interval.start }}' and '{{ interval.end }}'
+order by time at time zone 'Europe/Madrid'
+
+

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-historic/visualizations/chart.yaml
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-historic/visualizations/chart.yaml
@@ -1,0 +1,80 @@
+description: ''
+name: Chart
+options:
+  showDataLabels: false
+  direction:
+    type: counterclockwise
+  missingValuesAsZero: true
+  error_y:
+    visible: true
+    type: data
+  numberFormat: 0,0[.]00000
+  yAxis:
+  - type: linear
+  - type: linear
+    opposite: true
+  series:
+    stacking: null
+    error_y:
+      visible: true
+      type: data
+  globalSeriesType: scatter
+  percentFormat: 0[.]00%
+  sortX: true
+  seriesOptions:
+    Florida:inversor2:
+      zIndex: 6
+      index: 0
+      type: scatter
+      yAxis: 0
+    Alcolea:inversor2:
+      zIndex: 1
+      index: 0
+      type: scatter
+      yAxis: 0
+    Alcolea:inversor3:
+      zIndex: 0
+      index: 0
+      type: scatter
+      yAxis: 0
+    Alcolea:inversor1:
+      zIndex: 2
+      index: 0
+      type: scatter
+      yAxis: 0
+    Matallana:inversor2:
+      zIndex: 4
+      index: 0
+      type: scatter
+      yAxis: 0
+    Matallana:inversor3:
+      zIndex: 5
+      index: 0
+      type: scatter
+      yAxis: 0
+    Matallana:inversor1:
+      zIndex: 3
+      index: 0
+      type: scatter
+      yAxis: 0
+  valuesOptions: {}
+  xAxis:
+    labels:
+      enabled: true
+    type: '-'
+  dateTimeFormat: DD/MM/YY HH:mm
+  columnMapping:
+    inverter_name: unused
+    hot_inverter: y
+    time: x
+    plant_name: unused
+    device_name: series
+  textFormat: ''
+  customCode: |-
+    // Available variables are x, ys, element, and Plotly
+    // Type console.log(x, ys); for more info about x and ys
+    // To plot your graph call Plotly.plot(element, ...)
+    // Plotly examples and docs: https://plot.ly/javascript/
+  legend:
+    enabled: true
+type: CHART

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-historic/visualizations/table.yaml
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-historic/visualizations/table.yaml
@@ -1,0 +1,4 @@
+description: ''
+name: Table
+options: {}
+type: TABLE

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-scatter/metadata.yaml
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-scatter/metadata.yaml
@@ -1,0 +1,13 @@
+can_edit: true
+data_source_id: datasources/plantmonitor.yaml
+description: null
+is_archived: false
+is_draft: false
+is_favorite: false
+is_safe: true
+name: 'Alarma 3: Inversors temperatura anòmala scatter'
+options:
+  parameters: []
+schedule: null
+tags: []
+version: 1

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-scatter/query.sql
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-scatter/query.sql
@@ -1,0 +1,35 @@
+select
+		date_trunc('hour', time) as time,
+		plant_name,
+		inverter_name,
+		min(tmp_diff)/10.0 as tmp_diff_min,
+		min(temperature_dc)/10.0 as temperature_dc_min
+	from (
+		SELECT
+			subireg.time AS TIME,
+			pl.name AS plant_name,
+			inv.name AS inverter_name,
+			subireg.temperature_dc as temperature_dc,
+			subireg.temperature_dc - subinvs.temperature_dc as tmp_diff
+		FROM inverterregistry AS subireg
+		LEFT JOIN inverter as inv ON inv.id = subireg.inverter
+		LEFT JOIN plant as pl ON pl.id = inv.plant
+		LEFT JOIN (
+			SELECT distinct on (time, plant)
+				subireg.time AS TIME,
+				pl.name AS plant_name,
+				inv.name AS inverter_name,
+				temperature_dc as temperature_dc
+			FROM inverterregistry AS subireg
+			LEFT JOIN inverter as inv ON inv.id = subireg.inverter
+			LEFT JOIN plant as pl ON pl.id = inv.plant
+	where now() - interval '1 hour' < time
+			order by time, plant, temperature_dc
+		) subinvs
+		ON subinvs.time = subireg.time and subinvs.plant_name = pl.name
+	) diff_inverter
+	where now() - interval '1 hour' < time
+	group by date_trunc('hour', time), plant_name, inverter_name
+	order by time, inverter_name
+
+

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-scatter/visualizations/chart.yaml
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-scatter/visualizations/chart.yaml
@@ -1,0 +1,50 @@
+description: ''
+name: Chart
+options:
+  showDataLabels: false
+  direction:
+    type: counterclockwise
+  missingValuesAsZero: true
+  error_y:
+    visible: true
+    type: data
+  numberFormat: 0,0[.]00000
+  yAxis:
+  - type: linear
+  - type: linear
+    opposite: true
+  series:
+    stacking: null
+    error_y:
+      visible: true
+      type: data
+  globalSeriesType: scatter
+  percentFormat: 0[.]00%
+  sortX: true
+  seriesOptions:
+    tmp_diff_min:
+      zIndex: 0
+      index: 0
+      type: scatter
+      yAxis: 0
+  valuesOptions: {}
+  xAxis:
+    labels:
+      enabled: true
+    type: '-'
+  dateTimeFormat: DD/MM/YY HH:mm
+  columnMapping:
+    inverter_name: unused
+    time: unused
+    temperature_dc_min: x
+    tmp_diff_min: y
+    plant_name: unused
+  textFormat: ''
+  customCode: |-
+    // Available variables are x, ys, element, and Plotly
+    // Type console.log(x, ys); for more info about x and ys
+    // To plot your graph call Plotly.plot(element, ...)
+    // Plotly examples and docs: https://plot.ly/javascript/
+  legend:
+    enabled: true
+type: CHART

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-scatter/visualizations/table.yaml
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-scatter/visualizations/table.yaml
@@ -1,0 +1,4 @@
+description: ''
+name: Table
+options: {}
+type: TABLE

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-via-lag/metadata.yaml
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-via-lag/metadata.yaml
@@ -1,0 +1,28 @@
+can_edit: true
+data_source_id: datasources/plantmonitor.yaml
+description: null
+is_archived: false
+is_draft: false
+is_favorite: false
+is_safe: true
+name: 'Alarma 3: Inversors temperatura anòmala via lag'
+options:
+  parameters:
+  - name: plant
+    title: plant
+    global: false
+    value: Alcolea
+    queryId: queries/all-plants
+    parentQueryId: 139
+    type: query
+    locals: []
+  - name: interval
+    title: interval
+    global: false
+    value: d_this_year
+    locals: []
+    type: datetime-range
+    parentQueryId: 139
+schedule: null
+tags: []
+version: 1

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-via-lag/query.sql
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-via-lag/query.sql
@@ -1,0 +1,46 @@
+select foo.*, plant.name as plant_name, inverter.name as inverter_name, plant.name || ':' || inverter.name as device_name from (
+	select hot_inv.*, 
+        interval '2 hours' < time - lag(time) over (order by inverter, time) as long_state_change_to_hot
+	from (
+		select time,
+			   plant as plant,
+			   inverter,
+			   tmp_diff,
+			   lag(tmp_diff,1) over (order by inverter, time) as previous_tmp_diff,
+			   hot_inverter,
+			   lag(hot_inverter,1) over (order by inverter, time) as previous_hot_inverter,
+			   hot_inverter != lag(hot_inverter,1) over (order by inverter, time) as hot_inverter_changed
+		  from (SELECT subireg.time AS TIME,
+				  pl.id AS plant,
+				  inv.id AS inverter,
+				  subireg.temperature_dc AS temperature_dc,
+				  subireg.temperature_dc - subinvs.temperature_dc AS tmp_diff,
+				  100 < (subireg.temperature_dc - subinvs.temperature_dc) and 400 < subireg.temperature_dc AS hot_inverter
+		  FROM inverterregistry AS subireg
+		  LEFT JOIN inverter AS inv ON inv.id = subireg.inverter
+		  LEFT JOIN plant AS pl ON pl.id = inv.plant
+		  LEFT JOIN
+			( SELECT DISTINCT ON (TIME,
+								  plant) subireg.time AS TIME,
+								 pl.id AS plant,
+								 inv.id AS inverter,
+								 temperature_dc AS temperature_dc
+			 FROM inverterregistry AS subireg
+			 LEFT JOIN inverter AS inv ON inv.id = subireg.inverter
+			 LEFT JOIN plant AS pl ON pl.id = inv.plant
+			   WHERE --pl.name = '{{ plant }}' and
+			   subireg.time >= '{{ interval.start }}'
+			   AND subireg.time <= '{{ interval.end }}'
+			 ORDER BY TIME,
+					  plant,
+					  temperature_dc ) subinvs ON subinvs.time = subireg.time AND subinvs.plant = pl.id
+		order by inverter,time desc
+		) inv_diff
+	) hot_inv
+	where hot_inverter_changed = true and hot_inverter = true
+	order by inverter, time desc
+) foo
+left join inverter on inverter.id = foo.inverter
+left join plant on plant.id = inverter.plant
+where long_state_change_to_hot = true and hot_inverter = true
+order by time desc, foo.plant, foo.inverter

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-via-lag/visualizations/chart.yaml
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-via-lag/visualizations/chart.yaml
@@ -1,0 +1,62 @@
+description: ''
+name: Chart
+options:
+  showDataLabels: false
+  direction:
+    type: counterclockwise
+  missingValuesAsZero: true
+  error_y:
+    visible: true
+    type: data
+  numberFormat: 0[.]00000
+  yAxis:
+  - type: category
+    rangeMin: null
+  - type: linear
+    opposite: true
+  series:
+    stacking: null
+    error_y:
+      visible: true
+      type: data
+  globalSeriesType: scatter
+  percentFormat: 0[.]00%
+  sortX: true
+  seriesOptions:
+    Alcolea:
+      zIndex: 1
+      index: 0
+      type: scatter
+      yAxis: 0
+    Florida:
+      zIndex: 0
+      index: 0
+      type: scatter
+      yAxis: 0
+    Matallana:
+      zIndex: 2
+      index: 0
+      type: scatter
+      yAxis: 0
+  valuesOptions: {}
+  xAxis:
+    labels:
+      enabled: true
+    type: datetime
+  dateTimeFormat: DD/MM/YY HH:mm
+  columnMapping:
+    plant: unused
+    device_name: y
+    plant_name: series
+    time: x
+    inverter_name: unused
+    inverter: unused
+  textFormat: '{{inverter_name}} {{time}}'
+  customCode: |-
+    // Available variables are x, ys, element, and Plotly
+    // Type console.log(x, ys); for more info about x and ys
+    // To plot your graph call Plotly.plot(element, ...)
+    // Plotly examples and docs: https://plot.ly/javascript/
+  legend:
+    enabled: true
+type: CHART

--- a/redash/queries/alarma-3-inversors-temperatura-anomala-via-lag/visualizations/table.yaml
+++ b/redash/queries/alarma-3-inversors-temperatura-anomala-via-lag/visualizations/table.yaml
@@ -1,0 +1,4 @@
+description: ''
+name: Table
+options: {}
+type: TABLE


### PR DESCRIPTION
Aquesta PR afegeix l'alarma de temperatura anòmala d'inversor fent servir el LAG per a marcar els canvis d'estat.

L'alarma:
Si la temperatura de l’inversor X és > 40ºC i la diferencia entre l’inversor X i el de menor temperatura és > a 10ºC durant 2 hores: marca event d'alarma

La query resultat és al fitxer del diff adjunt de la PR:
[redash/queries/alarma-3-inversors-temperatura-anomala-via-lag/query.sql](https://github.com/Som-Energia/plantmonitor/compare/redasher-commits...alarma_inverter_temperature?expand=1#diff-92afb894485429ffdb25405ab9218475845139368adf0a7174aca3a7248dc9fa)

La resta de versions (scatter, històric) s'han desestimat en favor a aquesta (per ara)

[La query al redash](https://redash.somenergia.coop/queries/139?p_plant=Alcolea&p_interval=d_this_year#223)

@JoanaFigueira t'he afegit com a reviewer per tenir la teva opinió de PRs de queries, a vere com ho veus