### PR TITLE
Maintenance context manager

### DIFF
--- a/maintenance/db_manager.py
+++ b/maintenance/db_manager.py
@@ -14,10 +14,18 @@ class DBManager():
         self.alchemy_engine = create_engine(self.engine_str, pool_recycle=3600, echo=self.echo)
         self.db_con = self.alchemy_engine.connect()
 
+    def __enter__(self):
+        #just use default constructor
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.close_db()
+
     def close_db(self):
         self.db_con.close()
         self.alchemy_engine.dispose()
 
+    # TODO remove this, use `with self.db_con.begin()` instead
     def create_session(self):
         return Session(self.alchemy_engine)
 

--- a/maintenance/test_maintenance.py
+++ b/maintenance/test_maintenance.py
@@ -352,14 +352,14 @@ class InverterMaintenanceTests(TestCase):
 
         debug = False
 
-        cls.dbmanager = DBManager(**db_info, echo=debug)
+        cls.dbmanager = DBManager(**db_info, echo=debug).__enter__()
 
         cls.factory = DbTestFactory(cls.dbmanager)
 
 
     @classmethod
-    def tearDownClass(cls) -> None:
-        cls.dbmanager.close_db()
+    def tearDownClass(cls):
+        cls.dbmanager.__exit__()
 
     def setUp(self):
         self.session = self.dbmanager.db_con.begin()

--- a/maintenance/test_maintenance.py
+++ b/maintenance/test_maintenance.py
@@ -373,7 +373,15 @@ class InverterMaintenanceTests(TestCase):
         df = pd.read_csv(csvfile, sep=',')
         return df
 
-    def test__update_bucketed_inverter_registry(self):
+    def test__timezone(self):
+        time = self.dbmanager.db_con.execute('''
+            set time zone 'UTC';
+            select time from (values (1, '2021-01-01 10:00+00:00'::timestamptz)) as t (id, time);
+            ''').fetchone()[0]
+
+        self.assertEqual(time.tzinfo, datetime.timezone.utc)
+
+    def test__update_bucketed_inverter_registry__base(self):
         try:
             self.factory.create('inverterregistry_factory_case1.csv', 'inverterregistry')
             self.factory.create_bucket_5min_inverterregistry_empty_table()
@@ -389,7 +397,7 @@ class InverterMaintenanceTests(TestCase):
             self.factory.delete('bucket_5min_inverterregistry')
             raise
 
-    def test__update_bucketed_inverter_registry_horary_change(self):
+    def test__update_bucketed_inverter_registry__DST(self):
         try:
             self.factory.create('inverterregistry_factory_case_horary_change.csv', 'inverterregistry')
             self.factory.create_bucket_5min_inverterregistry_empty_table()

--- a/plantmonitor/task.py
+++ b/plantmonitor/task.py
@@ -241,7 +241,7 @@ def task_integral():
     with orm.db_session:
         computeIntegralMetrics()
 
-def client_sqlalchemy_db_con():
+def get_db_info():
 
     database_info = envinfo.DB_CONF
     db_info = database_info.copy()
@@ -249,19 +249,16 @@ def client_sqlalchemy_db_con():
     del db_info['provider']
     del db_info['database']
 
-    debug = False
-
-    dbmanager = DBManager(**db_info, echo=debug)
-    dbmanager.db_con.begin()
-
-    return dbmanager
+    return db_info
 
 
 def task_maintenance():
     try:
-        dbmanager = client_sqlalchemy_db_con()
-        bucketed_registry_maintenance(dbmanager.db_con)
-        dbmanager.close_db()
+
+        db_info = get_db_info()
+        with DBManager(**db_info) as dbmanager:
+            with dbmanager.db_con.begin():
+                bucketed_registry_maintenance(dbmanager.db_con)
     except Exception as err:
         logger.error("[ERROR] %s" % err)
         raise

--- a/plantmonitor/test_task.py
+++ b/plantmonitor/test_task.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
+
+from maintenance.db_manager import DBManager
 os.environ.setdefault('PLANTMONITOR_MODULE_SETTINGS', 'conf.settings.testing')
 
 import unittest
@@ -12,7 +14,7 @@ from conf import envinfo
 
 from .task import (
     get_plant_reading,
-    client_sqlalchemy_db_con,
+    get_db_info,
 )
 
 from unittest.mock import MagicMock, Mock
@@ -52,11 +54,17 @@ class Task_Test(unittest.TestCase):
 
         self.assertIsNone(plant_data)
 
+    def test__get_db_info(self):
+        dbinfo = get_db_info()
+        # depends on local config just make sure it doesn't raise
+
     def test__client_sqlalchemy_db_con(self):
 
-        dbmanager = client_sqlalchemy_db_con()
-        result = dbmanager.db_con.execute('''
-            SELECT 1 AS COLUMN
-        ''').fetchone()
+        db_info = get_db_info()
+        with DBManager(**db_info) as dbmanager:
+            with dbmanager.db_con.begin():
+                result = dbmanager.db_con.execute('''
+                    SELECT 1 AS COLUMN
+                ''').fetchone()
 
         self.assertEqual(result[0], 1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ msgpack==0.6.1
 nose==1.3.7
 pony==0.7.13
 prompt-toolkit==3.0.5
-psycopg2==2.8.5
+psycopg2>=2.9
 Pygments==2.6.1
 pymodbus==2.3.0
 pyserial==3.4


### PR DESCRIPTION
Revisant el codi pel merge a maintenance he vistque el close_db no s'executaria si hi havia una excepció i ho he passat a patró context manager com voliem fer inicialment resolent el problema que ens vam trobar aleshores (init vs crear sessió). Podeu veure que enter simplement torna l'objecte construït com abans, però el context manager s'encarrega de fer el finally que hauria hagut de posar per resoldre el bug.

també he vist que no passaven tests perquè select no tornava UTC sinó fixedOffset. Investigant una mica he trobat a la doc de psycopg2 que a partir del 2.9 van canviar-ho per tornar un tzinfo millor. Ho he afegit als requirements.

Cal tenir en compte que quan fem el deploy d'això a la raspberrypi (sobretot la d'alcolea) pot ser un problema si és una versió no suportada. Això podria fer-nos avançar el separar el codi de manteniment del codi de plantmonitor o també accelerar separar el codi de servidor del codi de dispositiu, que jo lligaria amb passar a balenaOS.