### PR TITLE
Fix energy monthly target

### DIFF
--- a/ORM/models.py
+++ b/ORM/models.py
@@ -326,7 +326,7 @@ def define_models(database):
                     **values
                 )
 
-        def setPlantTargetMonthlyEnergyHistoricMonthlyEnergy(
+        def setPlantExpectedMonthlyEnergy(
             self,
             time,
             monthlyTargetEnergyKWh,
@@ -336,10 +336,10 @@ def define_models(database):
                 'monthly_target_energy_kwh': monthlyTargetEnergyKWh,
                 'monthly_historic_energy_kwh': monthlyHistoricEnergyKWh,
             }
-            if self.plantTargetMonthlyEnergyHistoricMonthlyEnergy:
-                self.plantTargetMonthlyEnergyHistoricMonthlyEnergy.set(**values)
+            if self.plantExpectedMonthlyEnergy:
+                self.plantExpectedMonthlyEnergy.set(**values)
             else:
-                self.plantTargetMonthlyEnergyHistoricMonthlyEnergy = PlantTargetMonthlyEnergyHistoricMonthlyEnergy(
+                self.plantExpectedMonthlyEnergy = PlantExpectedMonthlyEnergy(
                     plantparameters=self,
                     **values
                 )
@@ -938,7 +938,7 @@ def define_models(database):
 
     class PlantParameters(database.Entity):
         plant = Required(Plant)
-        plant_target_historic_energy = Optional('PlantTargetMonthlyEnergyHistoricMonthlyEnergy')
+        plant_expected_monthly_energy = Optional('PlantExpectedMonthlyEnergy')
         peak_power_w = Required(int, size=64)
         nominal_power_w = Required(int, size=64)
         connection_date = Required(datetime.datetime, sql_type='TIMESTAMP WITH TIME ZONE', default=datetime.datetime.now(datetime.timezone.utc))
@@ -968,7 +968,7 @@ def define_models(database):
             pp = {k:v for k,v in pp.items() if v is not None}
             return pp
 
-    class PlantTargetMonthlyEnergyHistoricMonthlyEnergy(database.Entity):
+    class PlantExpectedMonthlyEnergy(database.Entity):
         plantparameters = Required(PlantParameters)
         time = Required(datetime.datetime, sql_type='TIMESTAMP WITH TIME ZONE', default=datetime.datetime.now(datetime.timezone.utc))
         monthly_target_energy_kwh = Required(int, size=64)

--- a/ORM/models.py
+++ b/ORM/models.py
@@ -326,7 +326,7 @@ def define_models(database):
                     **values
                 )
 
-        def setPlantExpectedMonthlyEnergy(
+        def setEstimateddMonthlyEnergy(
             self,
             time,
             monthlyTargetEnergyKWh,
@@ -336,10 +336,10 @@ def define_models(database):
                 'monthly_target_energy_kwh': monthlyTargetEnergyKWh,
                 'monthly_historic_energy_kwh': monthlyHistoricEnergyKWh,
             }
-            if self.plantExpectedMonthlyEnergy:
-                self.plantExpectedMonthlyEnergy.set(**values)
+            if self.plantEstimatedMonthlyEnergy:
+                self.plantEstimatedMonthlyEnergy.set(**values)
             else:
-                self.plantExpectedMonthlyEnergy = PlantExpectedMonthlyEnergy(
+                self.plantEstimatedMonthlyEnergy = PlantEstimatedMonthlyEnergy(
                     plantparameters=self,
                     **values
                 )
@@ -938,7 +938,7 @@ def define_models(database):
 
     class PlantParameters(database.Entity):
         plant = Required(Plant)
-        plant_expected_monthly_energy = Optional('PlantExpectedMonthlyEnergy')
+        plant_estimated_monthly_energy = Optional('PlantEstimatedMonthlyEnergy')
         peak_power_w = Required(int, size=64)
         nominal_power_w = Required(int, size=64)
         connection_date = Required(datetime.datetime, sql_type='TIMESTAMP WITH TIME ZONE', default=datetime.datetime.now(datetime.timezone.utc))
@@ -968,7 +968,7 @@ def define_models(database):
             pp = {k:v for k,v in pp.items() if v is not None}
             return pp
 
-    class PlantExpectedMonthlyEnergy(database.Entity):
+    class PlantEstimatedMonthlyEnergy(database.Entity):
         plantparameters = Required(PlantParameters)
         time = Required(datetime.datetime, sql_type='TIMESTAMP WITH TIME ZONE', default=datetime.datetime.now(datetime.timezone.utc))
         monthly_target_energy_kwh = Required(int, size=64)

--- a/ORM/schema.sql
+++ b/ORM/schema.sql
@@ -291,7 +291,7 @@ CREATE INDEX "idx_plantparameters__plant" ON "plantparameters" ("plant");
 
 ALTER TABLE "plantparameters" ADD CONSTRAINT "fk_plantparameters__plant" FOREIGN KEY ("plant") REFERENCES "plant" ("id");
 
-CREATE TABLE "planttargetmonthlyenergyhistoricmonthlyenergy" (
+CREATE TABLE "plantexpectedmonthlyenergy" (
   "id" SERIAL PRIMARY KEY,
   "plantparameters" INTEGER NOT NULL,
   "time" TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -299,9 +299,9 @@ CREATE TABLE "planttargetmonthlyenergyhistoricmonthlyenergy" (
   "monthly_historic_energy_kwh" BIGINT NOT NULL
 );
 
-CREATE INDEX "idx_planttargetmonthlyenergyhistoricmonthlyenergy__plantparamet" ON "planttargetmonthlyenergyhistoricmonthlyenergy" ("plantparameters");
+CREATE INDEX "idx_plantexpectedmonthlyenergy__plantparameters" ON "plantexpectedmonthlyenergy" ("plantparameters");
 
-ALTER TABLE "planttargetmonthlyenergyhistoricmonthlyenergy" ADD CONSTRAINT "fk_planttargetmonthlyenergyhistoricmonthlyenergy__plantparamete" FOREIGN KEY ("plantparameters") REFERENCES "plantparameters" ("id");
+ALTER TABLE "plantexpectedmonthlyenergy" ADD CONSTRAINT "fk_plantexpectedmonthlyenergy__plantparameters" FOREIGN KEY ("plantparameters") REFERENCES "plantparameters" ("id");
 
 CREATE TABLE "sensor" (
   "id" SERIAL PRIMARY KEY,

--- a/ORM/schema.sql
+++ b/ORM/schema.sql
@@ -291,7 +291,7 @@ CREATE INDEX "idx_plantparameters__plant" ON "plantparameters" ("plant");
 
 ALTER TABLE "plantparameters" ADD CONSTRAINT "fk_plantparameters__plant" FOREIGN KEY ("plant") REFERENCES "plant" ("id");
 
-CREATE TABLE "plantexpectedmonthlyenergy" (
+CREATE TABLE "plantestimatedmonthlyenergy" (
   "id" SERIAL PRIMARY KEY,
   "plantparameters" INTEGER NOT NULL,
   "time" TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -299,9 +299,9 @@ CREATE TABLE "plantexpectedmonthlyenergy" (
   "monthly_historic_energy_kwh" BIGINT NOT NULL
 );
 
-CREATE INDEX "idx_plantexpectedmonthlyenergy__plantparameters" ON "plantexpectedmonthlyenergy" ("plantparameters");
+CREATE INDEX "idx_plantestimatedmonthlyenergy__plantparameters" ON "plantestimatedmonthlyenergy" ("plantparameters");
 
-ALTER TABLE "plantexpectedmonthlyenergy" ADD CONSTRAINT "fk_plantexpectedmonthlyenergy__plantparameters" FOREIGN KEY ("plantparameters") REFERENCES "plantparameters" ("id");
+ALTER TABLE "plantestimatedmonthlyenergy" ADD CONSTRAINT "fk_plantestimatedmonthlyenergy__plantparameters" FOREIGN KEY ("plantparameters") REFERENCES "plantparameters" ("id");
 
 CREATE TABLE "sensor" (
   "id" SERIAL PRIMARY KEY,

--- a/ORM/schema.sql
+++ b/ORM/schema.sql
@@ -283,8 +283,6 @@ CREATE TABLE "plantparameters" (
   "n_modules_string" INTEGER,
   "inverter_loss_mpercent" INTEGER,
   "meter_loss_mpercent" INTEGER,
-  "target_monthly_energy_wh" BIGINT NOT NULL,
-  "historic_monthly_energy_wh" BIGINT,
   "month_theoric_pr_cpercent" BIGINT,
   "year_theoric_pr_cpercent" BIGINT
 );
@@ -292,6 +290,18 @@ CREATE TABLE "plantparameters" (
 CREATE INDEX "idx_plantparameters__plant" ON "plantparameters" ("plant");
 
 ALTER TABLE "plantparameters" ADD CONSTRAINT "fk_plantparameters__plant" FOREIGN KEY ("plant") REFERENCES "plant" ("id");
+
+CREATE TABLE "planttargetmonthlyenergyhistoricmonthlyenergy" (
+  "id" SERIAL PRIMARY KEY,
+  "plantparameters" INTEGER NOT NULL,
+  "time" TIMESTAMP WITH TIME ZONE NOT NULL,
+  "monthly_target_energy_kwh" BIGINT NOT NULL,
+  "monthly_historic_energy_kwh" BIGINT NOT NULL
+);
+
+CREATE INDEX "idx_planttargetmonthlyenergyhistoricmonthlyenergy__plantparamet" ON "planttargetmonthlyenergyhistoricmonthlyenergy" ("plantparameters");
+
+ALTER TABLE "planttargetmonthlyenergyhistoricmonthlyenergy" ADD CONSTRAINT "fk_planttargetmonthlyenergyhistoricmonthlyenergy__plantparamete" FOREIGN KEY ("plantparameters") REFERENCES "plantparameters" ("id");
 
 CREATE TABLE "sensor" (
   "id" SERIAL PRIMARY KEY,

--- a/ORM/yoyo/20220420_01_up8HQ-add-target-historic-energy-plant.py
+++ b/ORM/yoyo/20220420_01_up8HQ-add-target-historic-energy-plant.py
@@ -1,0 +1,29 @@
+"""
+Add planttargetmonthlyenergyhistoricmonthlyenergy table
+"""
+
+from yoyo import step
+
+__depends__ = {'20211213_01_m7M7G-solar-events', '20220413_01_VgHU3-change-plantparameters-to-bigint'}
+
+
+steps = [
+    step('''
+	CREATE TABLE "planttargetmonthlyenergyhistoricmonthlyenergy" (
+	  "id" SERIAL PRIMARY KEY,
+	  "plantparameters" INTEGER NOT NULL,
+	  "time" TIMESTAMP WITH TIME ZONE NOT NULL,
+	  "monthly_target_energy_kwh" BIGINT NOT NULL,
+	  "monthly_historic_energy_kwh" BIGINT NOT NULL
+	);
+
+	CREATE INDEX "idx_planttargetmonthlyenergyhistoricmonthlyenergy__plantparamet" 
+	       ON "planttargetmonthlyenergyhistoricmonthlyenergy" ("plantparameters");
+
+	ALTER TABLE "planttargetmonthlyenergyhistoricmonthlyenergy" 
+	      ADD CONSTRAINT "fk_planttargetmonthlyenergyhistoricmonthlyenergy__plantparamete" 
+	      FOREIGN KEY ("plantparameters") REFERENCES "plantparameters" ("id");
+        ''','''
+        DROP TABLE "planttargetmonthlyenergyhistoricmonthlyenergy";
+        ''')
+]

--- a/ORM/yoyo/20220420_01_up8HQ-add-target-historic-energy-plant.py
+++ b/ORM/yoyo/20220420_01_up8HQ-add-target-historic-energy-plant.py
@@ -1,5 +1,5 @@
 """
-Add planttargetmonthlyenergyhistoricmonthlyenergy table
+Add plantexpectedmonthlyenergy table
 """
 
 from yoyo import step
@@ -9,7 +9,7 @@ __depends__ = {'20211213_01_m7M7G-solar-events', '20220413_01_VgHU3-change-plant
 
 steps = [
     step('''
-	CREATE TABLE "planttargetmonthlyenergyhistoricmonthlyenergy" (
+	CREATE TABLE "plantexpectedmonthlyenergy" (
 	  "id" SERIAL PRIMARY KEY,
 	  "plantparameters" INTEGER NOT NULL,
 	  "time" TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -17,13 +17,11 @@ steps = [
 	  "monthly_historic_energy_kwh" BIGINT NOT NULL
 	);
 
-	CREATE INDEX "idx_planttargetmonthlyenergyhistoricmonthlyenergy__plantparamet" 
-	       ON "planttargetmonthlyenergyhistoricmonthlyenergy" ("plantparameters");
+	CREATE INDEX "idx_plantexpectedmonthlyenergy__plantparameters" ON "plantexpectedmonthlyenergy" ("plantparameters");
 
-	ALTER TABLE "planttargetmonthlyenergyhistoricmonthlyenergy" 
-	      ADD CONSTRAINT "fk_planttargetmonthlyenergyhistoricmonthlyenergy__plantparamete" 
+	ALTER TABLE "plantexpectedmonthlyenergy" ADD CONSTRAINT "fk_plantexpectedmonthlyenergy__plantparameters" 
 	      FOREIGN KEY ("plantparameters") REFERENCES "plantparameters" ("id");
         ''','''
-        DROP TABLE "planttargetmonthlyenergyhistoricmonthlyenergy";
+        DROP TABLE "plantexpectedmonthlyenergy";
         ''')
 ]

--- a/ORM/yoyo/20220420_01_up8HQ-add-target-historic-energy-plant.py
+++ b/ORM/yoyo/20220420_01_up8HQ-add-target-historic-energy-plant.py
@@ -1,5 +1,5 @@
 """
-Add plantexpectedmonthlyenergy table
+Add plantestimatedmonthlyenergy table
 """
 
 from yoyo import step
@@ -9,7 +9,7 @@ __depends__ = {'20211213_01_m7M7G-solar-events', '20220413_01_VgHU3-change-plant
 
 steps = [
     step('''
-	CREATE TABLE "plantexpectedmonthlyenergy" (
+	CREATE TABLE "plantestimatedmonthlyenergy" (
 	  "id" SERIAL PRIMARY KEY,
 	  "plantparameters" INTEGER NOT NULL,
 	  "time" TIMESTAMP WITH TIME ZONE NOT NULL,
@@ -17,11 +17,11 @@ steps = [
 	  "monthly_historic_energy_kwh" BIGINT NOT NULL
 	);
 
-	CREATE INDEX "idx_plantexpectedmonthlyenergy__plantparameters" ON "plantexpectedmonthlyenergy" ("plantparameters");
+	CREATE INDEX "idx_plantestimatedmonthlyenergy__plantparameters" ON "plantestimatedmonthlyenergy" ("plantparameters");
 
-	ALTER TABLE "plantexpectedmonthlyenergy" ADD CONSTRAINT "fk_plantexpectedmonthlyenergy__plantparameters" 
-	      FOREIGN KEY ("plantparameters") REFERENCES "plantparameters" ("id");
+        ALTER TABLE "plantestimatedmonthlyenergy" ADD CONSTRAINT "fk_plantestimatedmonthlyenergy__plantparameters" 
+              FOREIGN KEY ("plantparameters") REFERENCES "plantparameters" ("id");
         ''','''
-        DROP TABLE "plantexpectedmonthlyenergy";
+        DROP TABLE "plantestimatedmonthlyenergy";
         ''')
 ]

--- a/test_addPlant.py
+++ b/test_addPlant.py
@@ -259,7 +259,6 @@ class ImportPlant_Test(unittest.TestCase):
                         peakPowerMWp: 100000
                         nominalPowerMW: 80000
                         connectionDate: 2022-01-01
-                        targetMonthlyEnergyGWh: 0
                     meters:
                     - meter:
                         name: '1234578'
@@ -423,3 +422,4 @@ class ImportPlant_Test(unittest.TestCase):
             nsplants_original.plants[0].plant.codename = 'SomEnergia_Le_Roger_Nouveau_Meteo'
 
             self.assertNsEqual(nsplants_original, resultPlantNs)
+# vim: ts=4 sw=4 et


### PR DESCRIPTION
El objetivo de esta rama es crear una tabla para almacenar los datos de la energía objetivo mensual y el histórico mensual. Con esta nueva tabla se puede solucionar el bug de utilizar views para los campos.
Se modificó models para añadir la tabla y se creó una nueva migración del yoyo.

Propongo añadir en el futuro una modificación del export e import de plantas para añadir esta tabla. 

Pienso que podemos usar esta rama en prod para testear que todo va bien y si si no volver a máster.