### PR TITLE
add plant_uuid import export code and tests

### DIFF
--- a/ORM/models.py
+++ b/ORM/models.py
@@ -166,6 +166,8 @@ def define_models(database):
                 self.name = plant.name
             if 'description' in plant and self.description != plant['description']:
                 self.description = plant['description']
+            if 'plant_uuid' in plant and self.device_uuid != plant.plant_uuid:
+                self.device_uuid = plant.plant_uuid
             logger.info("Importing plant {}".format(self.name))
             if 'municipality' in plant:
                 m = Municipality.get(ineCode=plant['municipality'])
@@ -224,6 +226,7 @@ def define_models(database):
                         name = self.name,
                         codename = self.codename,
                         description = self.description,
+                        plant_uuid = str(self.device_uuid) if self.device_uuid else None,
                         meters    = [ns(meter=ns(name=meter.name)) for meter in Meter.select(lambda m: m.plant == self)],
                         inverters = [ns(inverter=ns(name=inverter.name) if not inverter.strings else
                                     ns(name=inverter.name, strings=sorted([s.name for s in inverter.strings])))
@@ -238,7 +241,8 @@ def define_models(database):
                 plantns = ns(
                         name = self.name,
                         codename = self.codename,
-                        description = self.description
+                        description = self.description,
+                        plant_uuid = str(self.device_uuid) if self.device_uuid else None
                 )
                 meters    = [ns(meter=ns(name=meter.name)) for meter in Meter.select(lambda m: m.plant == self)]
                 inverters = [ns(inverter=ns(name=inverter.name) if not inverter.strings else

--- a/ORM/schema.sql
+++ b/ORM/schema.sql
@@ -27,7 +27,8 @@ CREATE TABLE "plant" (
   "name" TEXT NOT NULL,
   "codename" TEXT NOT NULL,
   "municipality" INTEGER,
-  "description" TEXT NOT NULL
+  "description" TEXT NOT NULL,
+  "device_uuid" UUID
 );
 
 CREATE INDEX "idx_plant__municipality" ON "plant" ("municipality");
@@ -114,7 +115,8 @@ CREATE TABLE "inverter" (
   "plant" INTEGER NOT NULL,
   "brand" TEXT,
   "model" TEXT,
-  "nominal_power_w" INTEGER
+  "nominal_power_w" INTEGER,
+  "device_uuid" UUID
 );
 
 CREATE INDEX "idx_inverter__plant" ON "inverter" ("plant");
@@ -164,7 +166,8 @@ CREATE TABLE "meter" (
   "id" SERIAL PRIMARY KEY,
   "plant" INTEGER NOT NULL,
   "name" TEXT NOT NULL,
-  "connection_protocol" TEXT DEFAULT 'ip' NOT NULL
+  "connection_protocol" TEXT DEFAULT 'ip' NOT NULL,
+  "device_uuid" UUID
 );
 
 CREATE INDEX "idx_meter__plant" ON "meter" ("plant");
@@ -311,6 +314,7 @@ CREATE TABLE "sensor" (
   "name" TEXT NOT NULL,
   "plant" INTEGER NOT NULL,
   "description" TEXT NOT NULL,
+  "device_uuid" UUID,
   "classtype" TEXT NOT NULL,
   "ambient" BOOLEAN
 );
@@ -397,7 +401,8 @@ CREATE TABLE "string" (
   "id" SERIAL PRIMARY KEY,
   "inverter" INTEGER NOT NULL,
   "name" TEXT NOT NULL,
-  "stringbox_name" TEXT
+  "stringbox_name" TEXT,
+  "device_uuid" UUID
 );
 
 CREATE INDEX "idx_string__inverter" ON "string" ("inverter");

--- a/ORM/test_models.py
+++ b/ORM/test_models.py
@@ -77,6 +77,7 @@ class Models_Test(unittest.TestCase):
                 ineCode: '17079'
             plants:
             - plant:
+                plant_uuid: 7022523a-9f02-4f3c-9329-d30104521f75
                 name: alcolea
                 codename: SCSOM04
                 description: la bonica planta
@@ -88,6 +89,7 @@ class Models_Test(unittest.TestCase):
                 - inverter:
                     name: '5555'
             - plant:
+                plant_uuid: 7022523a-9f02-4f3c-9329-d30104521f75
                 name: figuerea
                 codename: Som_figuerea
                 description: la bonica planta
@@ -116,6 +118,7 @@ class Models_Test(unittest.TestCase):
 
     def samplePlantNS(self):
         alcoleaPlantNS = ns.loads("""\
+            plant_uuid: 7022523a-9f02-4f3c-9329-d30104521f75
             name: alcolea
             codename: SCSOM04
             description: la bonica planta
@@ -142,6 +145,7 @@ class Models_Test(unittest.TestCase):
     def samplePlantNSWithStrings(self):
         alcoleaPlantNS = ns.loads("""\
             name: alcolea
+            plant_uuid: 7022523a-9f02-4f3c-9329-d30104521f75
             codename: SCSOM04
             description: la bonica planta
             inverters:
@@ -158,6 +162,7 @@ class Models_Test(unittest.TestCase):
     def samplePlantNSWithModuleParameters(self):
         alcoleaPlantNS = ns.loads("""\
             name: alcolea
+            plant_uuid: 7022523a-9f02-4f3c-9329-d30104521f75
             codename: SCSOM04
             description: la bonica planta
             moduleParameters:
@@ -366,6 +371,7 @@ class Models_Test(unittest.TestCase):
             irradiationSensors: []
             meters: []
             name: alcolea
+            plant_uuid:
             temperatureAmbientSensors: []
             temperatureModuleSensors: []
             """)
@@ -716,7 +722,9 @@ class Models_Test(unittest.TestCase):
 
         plantData = oneplant.exportPlant()
 
-        expectedPlant = {"name": "Alice",
+        expectedPlant = {
+            "plant_uuid": None,
+            "name": "Alice",
             "codename": "LaSuisse",
             "description": '',
             "meters": [],

--- a/ORM/test_orm_util.py
+++ b/ORM/test_orm_util.py
@@ -346,6 +346,7 @@ class ORMSetup_Test(unittest.TestCase):
                 plants:
                 - plant:
                     name: alcolea
+                    plant_uuid:
                     codename: SCSOM04
                     description: la bonica planta
                     meters:

--- a/test_addPlant.py
+++ b/test_addPlant.py
@@ -75,6 +75,7 @@ class ImportPlant_Test(unittest.TestCase):
             nsplants = ns.loads("""\
                 plants:
                 - plant:
+                    plant_uuid: null
                     name: alcolea
                     codename: SCSOM04
                     description: la bonica planta
@@ -113,6 +114,7 @@ class ImportPlant_Test(unittest.TestCase):
         content = """\
             plants:
             - plant:
+                plant_uuid: 7022523a-9f02-4f3c-9329-d30104521f75
                 name: alcolea
                 codename: SCSOM04
                 description: la bonica planta
@@ -157,6 +159,7 @@ class ImportPlant_Test(unittest.TestCase):
         content = """\
             plants:
             - plant:
+                plant_uuid: 7022523a-9f02-4f3c-9329-d30104521f75
                 name: alcolea
                 codename: SCSOM04
                 description: la bonica planta
@@ -207,6 +210,7 @@ class ImportPlant_Test(unittest.TestCase):
                 province: Girona
             plants:
             - plant:
+                plant_uuid: 7022523a-9f02-4f3c-9329-d30104521f75
                 name: alcolea
                 codename: SCSOM04
                 description: la bonica planta
@@ -249,6 +253,7 @@ class ImportPlant_Test(unittest.TestCase):
             nsplants = ns.loads("""\
                 plants:
                 - plant:
+                    plant_uuid: 7022523a-9f02-4f3c-9329-d30104521f75
                     name: alcolea
                     codename: SCSOM04
                     description: la bonica planta
@@ -290,6 +295,7 @@ class ImportPlant_Test(unittest.TestCase):
             #TODO test the whole fixture, not just the plant data
             resultPlantNs = exportPlants(self.pony.db, skipEmpty=True)
             nsplants.plants[0].plant.description = ''
+            nsplants.plants[0].plant.plant_uuid = None
             nsplants.plants[0].plant.codename = 'SomEnergia_alcolea'
 
             self.assertNsEqual(nsplants, resultPlantNs)
@@ -312,6 +318,7 @@ class ImportPlant_Test(unittest.TestCase):
             #TODO test the whole fixture, not just the plant data
             resultPlantNs = exportPlants(self.pony.db, skipEmpty=True)
             nsplants.plants[0].plant.description = ''
+            nsplants.plants[0].plant.plant_uuid = None
             nsplants.plants[0].plant.codename = 'SomEnergia_new_plant'
 
             self.assertNsEqual(nsplants, resultPlantNs)
@@ -321,6 +328,7 @@ class ImportPlant_Test(unittest.TestCase):
         nsplants_original = ns.loads("""\
             plants:
             - plant:
+                plant_uuid: 7022523a-9f02-4f3c-9329-d30104521f75
                 name: Le_Roger
                 codename: SomEnergia_Le_Roger_Meteo
                 description: ohlala


### PR DESCRIPTION
## Description

added plant_uuid code for import export

## Changes

changed import export Plant and all its related tests to support the plant_uuid input and device_uuid column

## Observations

Note: import/export is mainly deprecated by dset, but I can't leave broken tests. I have lowered the coverage, however.

